### PR TITLE
Update repositories.json

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -91,6 +91,10 @@
 				{
 			"name": "Arn Burkhoff",
 			"location": "https://raw.githubusercontent.com/arnbme/nyckelharpa/master/repository.json"
+		},
+		{
+			"name": "Marco Felicio (maffpt@gmail.com)",
+			"location": "https://raw.githubusercontent.com/MAFFPT/Hubitat/master/Nuki%20Smart%20Lock%202.0/masterManifest.json"
 		}
 			],
 	"hpm": {


### PR DESCRIPTION
Included entry for "Nuki Smart Lock 2.0 Integration"

manifest located at:
https://raw.githubusercontent.com/MAFFPT/Hubitat/master/Nuki%20Smart%20Lock%202.0/masterManifest.json