### PR TITLE
Adding "Initial State" Integration Support

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -169,6 +169,10 @@
 			"location": "https://raw.githubusercontent.com/csteele-PD/Hubitat-public/master/repo.json"
 		},
 		{
+			"name": "jedbro",
+			"location": "https://raw.githubusercontent.com/jedbro/Hubitat-Projects/main/repositories.json"
+		},
+		{
 			"name": "SRWhite",
 			"location": "http://hubconnect.hubitatcommunity.com/HPM/HubConnectManifest.json"
 		}


### PR DESCRIPTION
A Hubitat App to allow Hubitat Evolution events to be viewable inside an Initial State Event Bucket in your https://www.initialstate.com account.