### PR TITLE
Update repositories.json

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -201,8 +201,8 @@
 			"location": "https://raw.githubusercontent.com/Botched1/Hubitat/master/packages/repository.json"
 		},
 		{
-			"name": "Hubitat Powerley",
-			"location": "https://raw.githubusercontent.com/bcastellucci/hubitat/main/powerley/packageManifest.json"
+			"name": "bchubitat",
+			"location": "https://raw.githubusercontent.com/bcastellucci/hubitat/main/repository.json"
 		}	
 	],
 	"hpm": {


### PR DESCRIPTION
Corrected copy-paste flub, should actually point to the repository file now (instead of the packageManifest of a package within), set the name right as well (instead of it being the name of a package within).