### PR TITLE
Include SnellRepository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -314,6 +314,10 @@
 		{
 			"name": "Michael van Dam",
 			"location": "https://raw.githubusercontent.com/michaelvandam/Hubitat/master/repository.json" 
+		},
+		{
+			"name": "Snell",
+			"location": "https://www.drdsnell.com/projects/hubitat/drivers/SnellRepository.json" 
 		}
 	],
 	"hpm": {


### PR DESCRIPTION
Unless it absolutely has to be in github, please add my repository so users have access to my drivers in HPM going forward.
I have a number of requests from users to support HPM so I would like to try it with a couple drivers first before having to add all of them in.