### PR TITLE
Removal of Mircolino repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -60,10 +60,6 @@
 			"location": "https://raw.githubusercontent.com/funzie19/hubitat-solaredge/master/repositories.json"
 		},
 		{
-			"name": "mircolino",
-			"location": "https://raw.githubusercontent.com/mircolino/ecowitt/master/repository.json"
-		},
-		{
 			"name": "Anthony S. (tonesto7)",
 			"location": "https://raw.githubusercontent.com/tonesto7/hubitat/master/repository.json"
 		},


### PR DESCRIPTION
Following Mirco's move away from HE, I thought it appropriate to remove his repo from the HPM list, given he has moved the repository from the location linked in this json file.