### PR TITLE
Add VisualAlert to Hubitat Package Manager

### DIFF
--- a/repos/techbill/visualalert/repository.json
+++ b/repos/techbill/visualalert/repository.json
@@ -1,0 +1,20 @@
+{
+  "author": "Bill Fleming (techbill@protonmail.com)",
+  "gitHubUrl": "https://github.com/TechBill",
+  "paypalUrl": "https://paypal.me/techbill?country.x=US&locale.x=en_US",
+  "packages": [
+    {
+      "name": "VisualAlert",
+      "category": "Convenience",
+      "location": "https://raw.githubusercontent.com/TechBill/visualalert/main/manifest.json",
+      "description": "Advanced visual notification system optimized for deaf and hard of hearing users.",
+      "tags": [
+        "Accessibility",
+        "Smart Lighting",
+        "Notification",
+        "Visual Alerts",
+        "Security"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds the VisualAlert package to Hubitat Package Manager.

VisualAlert is a parent/child app system designed specifically for deaf and hard of hearing users. It enables smart bulbs, switches, dimmers, and outlets to flash or change colors in response to various triggers, such as motion sensors, contact sensors, switches, buttons, and more.

Key Features:
- Multiple visual alert patterns (Simple Flash, Emergency, Doorbell, Custom, etc.)
- Support for color-capable and dimmable devices
- Trigger sources: switches, sensors, buttons, etc.
- Optional scheduling, conditions, and failsafe timeout
- Restore previous device states after alerts
- Test buttons and alert disabling switch
- Designed with accessibility and reliability in mind

This package is hosted at:  
https://github.com/TechBill/visualalert

The manifest file is located at:  
https://raw.githubusercontent.com/TechBill/visualalert/main/manifest.json

Donation support is optional and available via:  
https://paypal.me/techbill
